### PR TITLE
Create Dockerfile for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:centos6
+
+# Enable EPEL for Node.js
+RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+
+# Install Node.js and npm
+RUN yum install -y npm
+RUN yes | yum install mysql-server
+
+# Bundle app source
+COPY . .
+
+# Install app dependencies
+RUN npm install
+
+EXPOSE  3000
+
+CMD ./installer.sh

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,3 @@
+service mysqld start
+mysql -u root < ./server/db/schema.sql
+node index.js


### PR DESCRIPTION
We're deploying our app back end to a CentOS 6 docker container. The Dockerfile sets forth the docker image build process by:
1. Setting up the project files; and
2. Running installer.sh, which implements our db schema and starts the node server.
