### PR TITLE
Update MySQL Schema for scoring system

### DIFF
--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -36,5 +36,6 @@ CREATE TABLE votes (
 
 CREATE TABLE users (
   id int(5) AUTO_INCREMENT,
-  PRIMARY KEY(id)
+  PRIMARY KEY(id),
+  userToken VARCHAR(255)
 );

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -1,3 +1,4 @@
+DROP DATABASE uncovery;
 CREATE DATABASE uncovery;
 
 SET foreign_key_checks=0;
@@ -6,18 +7,34 @@ USE uncovery;
 
 CREATE TABLE marks (
   id int(5) AUTO_INCREMENT,
+  PRIMARY KEY (id),
   x float(10, 6),
   y float(10, 6),
   z float(10, 6),
   timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
   messageId int(5),
-  FOREIGN KEY (messageId)
-    REFERENCES messages(id),
-  PRIMARY KEY (id)
+  FOREIGN KEY (messageId) REFERENCES messages(id),
+  userId int(5),
+  FOREIGN KEY (userId) REFERENCES users(id)
 );
 
 CREATE TABLE messages (
   id int(5) AUTO_INCREMENT,
+  PRIMARY KEY (id),
   messageString text,
-  PRIMARY KEY (id)
+  score int(5) DEFAULT 0
+);
+
+CREATE TABLE votes (
+  id int(5) AUTO_INCREMENT, 
+  PRIMARY KEY(id),
+  userId int(5),
+  FOREIGN KEY (userId) REFERENCES users(id),
+  messageId int(5),
+  FOREIGN KEY (messageId) REFERENCES messages(id)
+);
+
+CREATE TABLE users (
+  id int(5) AUTO_INCREMENT,
+  PRIMARY KEY(id)
 );


### PR DESCRIPTION
The "primary key" field now comes after the "id" field to more clearly associate the relationship between the two entities.

I included "DROP DATABASE uncovery;" as the first line for rapid schema updating. The only time we would run "CREATE DATABASE uncovery;" is when the uncovery database does not exist anyways.

I added the "votes" table and the "user" table to enable us to implement the scoring system we planned.
