### PR TITLE
Add CircleCI for Continuous Integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,8 @@ module.exports = function(grunt) {
     mochaTest: {
       test: {
         options: {
-          reporter: 'spec'
+          reporter: 'spec',
+          require: 'index.js'
         },
         src: ['specs/**/*.js']
       }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Circle CI](https://circleci.com/gh/team-oath/uncovery.svg?style=badge)](https://circleci.com/gh/team-oath/uncovery)
 <h1>Project: Uncovery</h1>
 <h2>Getting Started</h3>
 <ol>

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,45 @@
+## Customize the test machine
+machine:
+
+  # Version of ruby to use
+  node:
+    version: 0.12.2
+
+  # Override /etc/hosts
+  hosts:
+    circlehost: 127.0.0.1
+
+  # Add some environment variables
+  environment:
+    CIRCLE_ENV: test
+    DATABASE_URL: mysql://ubuntu:@127.0.0.1:3306/
+
+## Customize dependencies
+dependencies:
+  pre:
+    - npm install  # install from a different package manager
+
+  override:
+    - npm install: # note ':' here
+        timeout: 180 # fail if command has no output for 3 minutes
+
+## Customize database setup
+database:
+  override:
+    - mysql -u ubuntu circle_test < server/db/schema.sql
+
+## Customize test commands
+test:
+  override:
+    - ./node_modules/grunt-cli/bin/grunt test # use grunt for testing
+
+## Customize deployment commands
+# deployment:
+#   staging:
+#     branch: master
+
+## Custom notifications
+# notify:
+#   webhooks:
+#     # A list of hashes representing hooks. Only the url field is supported.
+    # - url: https://someurl.com/hooks/circle

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-uglify": "^0.9.1",


### PR DESCRIPTION
Reconfigured the gruntfile to be able to run tests without having the node server running in the background. This allows CircleCI to easily run tests in a similar environment to our local machines. Also, this adds a badge to our readme indicating whether or not the build is passing.
