### PR TITLE
Fix fatal MySQL connection error

### DIFF
--- a/server/db/config.js
+++ b/server/db/config.js
@@ -1,11 +1,31 @@
 var mysql = require('mysql');
 
-exports.connection = mysql.createConnection({
+var connection;
+var db_config = {
   host: 'localhost',
   user: 'root',
   database: 'uncovery'
-});
-
-exports.initialize = function(callback) {
-  exports.connection.connect();
 };
+
+handleDisconnect();
+exports.connection = connection;
+
+function handleDisconnect() {
+  connection = mysql.createConnection(db_config);
+
+  connection.connect(function(err) {
+    if(err) {
+      console.log('error when connecting to db:', err);
+      setTimeout(handleDisconnect, 2000);
+    }
+  });
+
+  connection.on('error', function(err) {
+    console.log('db error', err);
+    if(err.code === 'PROTOCOL_CONNECTION_LOST') {
+      handleDisconnect();
+    } else {
+      throw err;
+    }
+  });
+}

--- a/server/db/modelAdapters.js
+++ b/server/db/modelAdapters.js
@@ -1,7 +1,6 @@
 var db = require('./config');
 var util = require('../core/utilities');
 
-db.initialize();
 
 // insert(string, object)
 exports.insert = function(table, data) {


### PR DESCRIPTION
Per our MySQL module's [documentation](https://github.com/felixge/node-mysql#server-disconnects), if for any reason our Node server has connection issues with the MySQL database, a fatal error will cause the server to crash. This catches the fatal error and attempts to reconnect to the database.

We'll also implement a `forever` module shortly to avoid entire application crashes in the future.
