### PR TITLE
Prevent duplicate voting and include user vote status on mark retrieval [fixes #61]

### DIFF
--- a/server/core/utilities.js
+++ b/server/core/utilities.js
@@ -17,6 +17,22 @@ exports.getDistanceFrom = function(mark, user) {
   return dist + 'm';
 };
 
+exports.decorateMarksWithVoteStatus = function(marks, votes) {
+  var voted = {};
+  for (var k = 0;k < votes.length;k++) {
+    voted[votes[k].messageId] = true;
+  }
+  for (var i = 0;i < marks.length;i++) {
+    var markMessageId = marks[i].messageId;
+    if (voted[markMessageId]) {
+      marks[i].voted = true;
+    } else {
+      marks[i].voted = false;
+    }
+  }
+  return marks;
+};
+
 // The object we pull from the database has specific data (time/location)
 // Here we create a new object that has data that is relevant to the user
 exports.createMessageResponseObjects = function(marks, user) {
@@ -36,7 +52,6 @@ exports.createMessageResponseObjects = function(marks, user) {
     };
     responseObjects.push(responseObject);
   });
-
   return responseObjects;
 };
 

--- a/server/db/modelAdapters.js
+++ b/server/db/modelAdapters.js
@@ -92,8 +92,9 @@ exports.retrieveCount = function(table, filters) {
       }
     });
   });
-}
+};
 
+//exports.retrieveMarks({x: float, y: float, z: float, userToken: string})
 exports.retrieveMarks = function(userData) {
   return new Promise(function(resolve, reject) {
     var query = ([
@@ -116,7 +117,6 @@ exports.retrieveMarks = function(userData) {
       +userData.y - .01,
         +userData.y + .01
     ];
-
 
     db.connection.query(query, params, function(err, marks) {
       if (err) {

--- a/server/db/models.js
+++ b/server/db/models.js
@@ -72,10 +72,24 @@ exports.createVote = function(userData) {
   return db.insert('votes', voteObject);
 };
 
-//exports.retrieveMarks({x: 10, y: 10, z: 10, userToken: 'bbq'}).then(callback(success));
+
+//exports.retrieveVotesByUser(userToken string)
+exports.retrieveVotesByUser = function(userToken) {
+  return db.where('votes', ['userToken', userToken]); 
+};
+
+//exports.retrieveMarks({x: float, y: float, z: float, userToken: string})
 exports.retrieveMarks = function(userData) {
   if (validate.validateCoordinates(userData)) {
-    return db.retrieveMarks(userData);
+    return db.retrieveMarks(userData)
+      .then(function(marks) {
+      return exports.retrieveVotesByUser(userData.userToken)
+        .then(function(votes) {
+        return new Promise(function(resolve) {
+          resolve(util.decorateMarksWithVoteStatus(marks, votes));
+        });
+      });
+    });
   } else {
     return new Promise(function(resolve, reject) {
       reject('Validations failed. Please enter valid coordinates');
@@ -104,11 +118,6 @@ exports.updateScore = function(messageId, amount) {
 //exports.retrieveVotes(10).then(function(success){console.log(success)});
 exports.retrieveVotes = function(messageId) {
   return db.retrieveCount('votes', ['messageId', messageId]);
-};
-
-//exports.retrieveVotesByUser('Zealot')
-exports.retrieveVotesByUser = function(userToken) {
-  return db.where('votes', ['userToken', userToken]); 
 };
 
 //exports.retrieveComments(10).then(function(success){console.log(success)});
@@ -149,3 +158,4 @@ exports.deleteMarkByUserToken = function(userToken) {
 exports.deleteMessagesByScore = function(score) {
   return db.deleteRow('messages', ['score', score]);
 };
+

--- a/server/db/models.js
+++ b/server/db/models.js
@@ -106,6 +106,11 @@ exports.retrieveVotes = function(messageId) {
   return db.retrieveCount('votes', ['messageId', messageId]);
 };
 
+//exports.retrieveVotesByUser('Zealot')
+exports.retrieveVotesByUser = function(userToken) {
+  return db.where('votes', ['userToken', userToken]); 
+};
+
 //exports.retrieveComments(10).then(function(success){console.log(success)});
 exports.retrieveComments = db.retrieveComments;
 // exports.retrieveComments = function(messageId) {

--- a/server/db/models.js
+++ b/server/db/models.js
@@ -12,6 +12,7 @@ exports.createMessage = function(userData) {
   }
 
   return db.insert('messages', {
+    userToken: userData.userToken,
     messageString: userData.message,
     image: util.saveImage(userData.image),
     score: userData.score || 0
@@ -71,7 +72,7 @@ exports.createVote = function(userData) {
   return db.insert('votes', voteObject);
 };
 
-//exports.retrieveMarks({x: 10, y: 10, z: 10}).then(callback(success));
+//exports.retrieveMarks({x: 10, y: 10, z: 10, userToken: 'bbq'}).then(callback(success));
 exports.retrieveMarks = function(userData) {
   if (validate.validateCoordinates(userData)) {
     return db.retrieveMarks(userData);

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -22,8 +22,9 @@ CREATE TABLE marks (
 
 CREATE TABLE messages (
   id int(5) AUTO_INCREMENT,
+  userToken VARCHAR(255),
   messageString text,
-  image varchar(255),
+  image VARCHAR(255),
   score int(5) DEFAULT 0,
   PRIMARY KEY (id)
 );
@@ -51,5 +52,16 @@ CREATE TABLE votes (
 
 CREATE TABLE users (
   token VARCHAR(255),
-  PRIMARY KEY(token)
+  PRIMARY KEY(token),
+  total_votes int(5) DEFAULT 0
 );
+
+-- If a message does not have a userToken then this will not work
+DELIMITER //
+CREATE TRIGGER vote_increment AFTER INSERT ON votes
+FOR EACH ROW
+  BEGIN
+    UPDATE users SET users.total_votes = (users.total_votes + 1) WHERE users.token = 
+      (SELECT userToken FROM messages WHERE id = NEW.messageId);
+  END;//
+DELIMITER ;

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -44,7 +44,9 @@ CREATE TABLE votes (
   commentId int(5) NULL,
   FOREIGN KEY (userToken) REFERENCES users(token),
   FOREIGN KEY (messageId) REFERENCES messages(id),
-  FOREIGN KEY (commentId) REFERENCES comments(id)
+  FOREIGN KEY (commentId) REFERENCES comments(id),
+  UNIQUE KEY (userToken, messageId),
+  UNIQUE KEY (userToken, commentId)
 );
 
 CREATE TABLE users (

--- a/server/db/seedData.sql
+++ b/server/db/seedData.sql
@@ -25,3 +25,10 @@ INSERT INTO votes (userToken, messageId) VALUES ('Zealot', 2);
 INSERT INTO votes (userToken, messageId) VALUES ('Zealot', 3);
 INSERT INTO votes (userToken, messageId) VALUES ('Marine', 1);
 INSERT INTO votes (userToken, messageId) VALUES ('Ghost', 1);
+
+INSERT INTO marks (userToken, messageId, x, y, z) VALUES ('Zealot', 1, 20, 20, 20);
+INSERT INTO marks (userToken, messageId, x, y, z) VALUES ('Zealot', 2, 20, 20, 20);
+INSERT INTO marks (userToken, messageId, x, y, z) VALUES ('Dark Templar', 3, 25, 25, 25);
+INSERT INTO marks (userToken, messageId, x, y, z) VALUES ('SCV', 4, 10, 10, 10);
+INSERT INTO marks (userToken, messageId, x, y, z) VALUES ('Marine', 5, 10, 10, 10);
+INSERT INTO marks (userToken, messageId, x, y, z) VALUES ('Marine', 6, 10, 10, 10);

--- a/server/db/seedData.sql
+++ b/server/db/seedData.sql
@@ -1,0 +1,27 @@
+USE uncovery;
+
+INSERT INTO users (token) VALUES ('Archon');
+INSERT INTO users (token) VALUES ('Carrier');
+INSERT INTO users (token) VALUES ('Colossus');
+INSERT INTO users (token) VALUES ('Dark Templar');
+INSERT INTO users (token) VALUES ('Zealot');
+INSERT INTO users (token) VALUES ('SCV');
+INSERT INTO users (token) VALUES ('Raven');
+INSERT INTO users (token) VALUES ('Marine');
+INSERT INTO users (token) VALUES ('Ghost');
+INSERT INTO users (token) VALUES ('Drone');
+INSERT INTO users (token) VALUES ('Zergling');
+INSERT INTO users (token) VALUES ('Broodling');
+
+INSERT INTO messages (userToken, messageString) VALUES ('Zealot', 'State your will.');
+INSERT INTO messages (userToken, messageString) VALUES ('Zealot', 'For Aiur!');
+INSERT INTO messages (userToken, messageString) VALUES ('Dark Templar', 'Nach nagalas.');
+INSERT INTO messages (userToken, messageString) VALUES ('SCV', 'SCV good to go, sir.');
+INSERT INTO messages (userToken, messageString) VALUES ('Marine', 'You wanna piece of me, boy?');
+INSERT INTO messages (userToken, messageString) VALUES ('Marine', 'Gimme something to shoot!');
+
+INSERT INTO votes (userToken, messageId) VALUES ('Zealot', 1);
+INSERT INTO votes (userToken, messageId) VALUES ('Zealot', 2);
+INSERT INTO votes (userToken, messageId) VALUES ('Zealot', 3);
+INSERT INTO votes (userToken, messageId) VALUES ('Marine', 1);
+INSERT INTO votes (userToken, messageId) VALUES ('Ghost', 1);

--- a/server/routes/getRoutes.js
+++ b/server/routes/getRoutes.js
@@ -3,7 +3,7 @@ var util = require('../core/utilities.js');
 
 module.exports = function(router) {
 
-  //{x: float, y: float, z: float}
+  //{x: float, y: float, z: float, userToken: string}
   router.get('/messages', function (req, res) {
     models.retrieveMarks(req.query).then(
       util.resolveGET.bind(this, req, res),


### PR DESCRIPTION
Included new method: retrieveVotesByUser
--By default all retrieve methods will accept an argument of messageId, unless
specifically stated otherwise in the method identifier. For example:
retrieveVotesByUser

Included new method: decorateMarksWithVoteStatus
--This method is responsible for decorating the mark objects which are being returned from the server with an additional property called 'voted'. The 'voted' property indicated whether a given user has voted on the mark object in question. The purpose of decorating the marks with this property is so we can display to the user within the UI which messages they have already voted on.

Added SQL constraint to prevent duplicate voting
-See schema.sql

Created MySQL trigger which increments a users 'total_votes' whenever any of their messages receive a vote from another user
-see schema.sql

Added Seed Data for MySQL
--The point of having database seed data in this application is strictly for rapid
debugging in a development environment.
